### PR TITLE
Move wp-cli command before 'enabled' check

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -21,16 +21,16 @@ function init() {
 		return;
 	}
 
+	if ( defined( 'WP_CLI' ) && WP_CLI ) {
+		\WP_CLI::add_command( 's3-uploads', 'S3_Uploads\\WP_CLI_Command' );
+	}
+
 	if ( ! enabled() ) {
 		return;
 	}
 
 	if ( ! defined( 'S3_UPLOADS_REGION' ) ) {
 		wp_die( 'S3_UPLOADS_REGION constant is required. Please define it in your wp-config.php' );
-	}
-
-	if ( defined( 'WP_CLI' ) && WP_CLI ) {
-		\WP_CLI::add_command( 's3-uploads', 'S3_Uploads\\WP_CLI_Command' );
 	}
 
 	$instance = Plugin::get_instance();


### PR DESCRIPTION
Currently, when `S3_UPLOADS_AUTOENABLE` is set to `false` the `wp-cli` command doesn't work.